### PR TITLE
Add the Properties and ObjectManager interfaces for the provide side

### DIFF
--- a/src/Dbus.CodeGenerator/EncoderGenerator.cs
+++ b/src/Dbus.CodeGenerator/EncoderGenerator.cs
@@ -12,7 +12,7 @@ namespace Dbus.CodeGenerator
             {
                 encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") =>
             {
-                foreach (var "+parameterName+"_e" + resultParameter + " in " + parameterName + resultParameter + @")  
+                foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @")
                 {");
                 signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1);
                 encoders.Append(@"
@@ -25,7 +25,7 @@ namespace Dbus.CodeGenerator
             {
                 foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @") 
                 {
-                    global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);") ;
+                    global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);");
                 signature += "a{" + dictionaryKeyStep(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
                                       + dictionaryValueStep(type.GenericTypeArguments[1], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
                                       + "}";
@@ -70,7 +70,7 @@ namespace Dbus.CodeGenerator
             return signature;
         }
 
-        private static string dictionaryKeyStep(Type type, StringBuilder encoders, string parameterName ,string parameter = "", string resultParameter = "", int level = 0)
+        private static string dictionaryKeyStep(Type type, StringBuilder encoders, string parameterName, string parameter = "", string resultParameter = "", int level = 0)
         {
             string signature = "";
             if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
@@ -79,7 +79,7 @@ namespace Dbus.CodeGenerator
             {
                 foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Key) 
                 {");
-                signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName , parameter + "_e", resultParameter + "_e", level + 1);
+                signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1);
                 encoders.Append(@"
                 }
             });");

--- a/src/Dbus.CodeGenerator/EncoderGenerator.cs
+++ b/src/Dbus.CodeGenerator/EncoderGenerator.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Text;
+
+namespace Dbus.CodeGenerator
+{
+    public static class EncoderGenerator
+    {
+
+        public static string buildSignature(Type type, StringBuilder encoders, string parameterName = "result", string parameter = "", string resultParameter = "", int level = 0)
+        {
+            string signature = "";
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") =>
+            {
+                foreach (var "+parameterName+"_e" + resultParameter + " in " + parameterName + resultParameter + @")  
+                {
+                 ");
+                signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1);
+                encoders.AppendLine(@"  }
+                });");
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") => 
+            {
+                foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @") 
+                {
+                    global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);") ;
+                signature += "a{" + dictionaryKeyStep(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
+                                      + dictionaryValueStep(type.GenericTypeArguments[1], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
+                                      + "}";
+                encoders.AppendLine(@"
+                }
+            }, true);");
+            }
+            else if (type == typeof(object))
+            {
+                signature += SignatureString.For[type];
+                if (level > 0)
+                    encoders.AppendLine(@"
+                    global::Dbus.Encoder.AddVariant(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ");");
+                else
+                    encoders.AppendLine("global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
+            }
+            else
+            {
+                signature += SignatureString.For[type];
+                if (level > 0)
+                    encoders.AppendLine(@"
+                    global::Dbus.Encoder.Add(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ");");
+                else
+                    encoders.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
+            }
+
+            return signature;
+        }
+
+
+
+        public static string buildSignature(Type type)
+        {
+            string signature = "";
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                signature += "a" + buildSignature(type.GenericTypeArguments[0]);
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                signature += "a{" + buildSignature(type.GenericTypeArguments[0])
+                                      + buildSignature(type.GenericTypeArguments[1])
+                                      + "}";
+            }
+            else
+            {
+                signature += SignatureString.For[type];
+            }
+
+            return signature;
+        }
+
+        private static string dictionaryKeyStep(Type type, StringBuilder encoders, string parameterName ,string parameter = "", string resultParameter = "", int level = 0)
+        {
+            string signature = "";
+
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") => 
+            {
+                foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Key) 
+                {
+                ");
+                signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName , parameter + "_e", resultParameter + "_e", level + 1);
+                encoders.AppendLine(@"
+                }
+            });");
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") => 
+            {
+                foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Key) 
+                {
+                    global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);
+                                            ");
+                signature += "a{" + dictionaryKeyStep(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
+                                      + dictionaryValueStep(type.GenericTypeArguments[1], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
+                                      + "}";
+                encoders.AppendLine(@"
+                }
+            }, true);");
+            }
+            else if (type == typeof(object))
+            {
+                signature += SignatureString.For[type];
+                if (level > 0)
+                    encoders.AppendLine(@"
+                    global::Dbus.Encoder.AddVariant(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ".Key);");
+                else
+                    encoders.AppendLine("global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
+            }
+            else
+            {
+                signature += SignatureString.For[type];
+                if (level > 0)
+                    encoders.AppendLine(@"
+                    global::Dbus.Encoder.Add(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ".Key);");
+                else
+                    encoders.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
+            }
+
+            return signature;
+        }
+
+        private static string dictionaryValueStep(Type type, StringBuilder encoders, string parameterName, string parameter = "", string resultParameter = "", int level = 0)
+        {
+            string signature = "";
+
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") => 
+            {
+                foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Value) 
+                {
+                                        ");
+                signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1);
+                encoders.AppendLine(@"
+                }
+            });");
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") => 
+            {
+                foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Value) 
+                {
+                   global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);");
+                signature += "a{" + dictionaryKeyStep(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
+                                      + dictionaryValueStep(type.GenericTypeArguments[1], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
+                                      + "}";
+                encoders.AppendLine(@"
+                }
+            }, true);");
+            }
+            else if (type == typeof(object))
+            {
+                signature += SignatureString.For[type];
+                if (level > 0)
+                    encoders.AppendLine(@"
+                    global::Dbus.Encoder.AddVariant(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ".Value);");
+                else
+                    encoders.AppendLine("global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
+            }
+            else
+            {
+                signature += SignatureString.For[type];
+                if (level > 0)
+                    encoders.AppendLine(@"
+                    global::Dbus.Encoder.Add(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ".Value);");
+                else
+                    encoders.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
+            }
+
+            return signature;
+        }
+
+    }
+}

--- a/src/Dbus.CodeGenerator/EncoderGenerator.cs
+++ b/src/Dbus.CodeGenerator/EncoderGenerator.cs
@@ -5,7 +5,6 @@ namespace Dbus.CodeGenerator
 {
     public static class EncoderGenerator
     {
-
         public static string buildSignature(Type type, StringBuilder encoders, string parameterName = "result", string parameter = "", string resultParameter = "", int level = 0)
         {
             string signature = "";
@@ -14,11 +13,11 @@ namespace Dbus.CodeGenerator
                 encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") =>
             {
                 foreach (var "+parameterName+"_e" + resultParameter + " in " + parameterName + resultParameter + @")  
-                {
-                 ");
+                {");
                 signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1);
-                encoders.AppendLine(@"  }
-                });");
+                encoders.Append(@"
+                }
+            });");
             }
             else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
             {
@@ -38,60 +37,50 @@ namespace Dbus.CodeGenerator
             {
                 signature += SignatureString.For[type];
                 if (level > 0)
-                    encoders.AppendLine(@"
+                    encoders.Append(@"
                     global::Dbus.Encoder.AddVariant(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ");");
                 else
-                    encoders.AppendLine("global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
+                    encoders.Append(@"
+            global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
             }
             else
             {
                 signature += SignatureString.For[type];
                 if (level > 0)
-                    encoders.AppendLine(@"
+                    encoders.Append(@"
                     global::Dbus.Encoder.Add(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ");");
                 else
-                    encoders.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
+                    encoders.Append(@"
+            global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
             }
-
             return signature;
         }
-
-
 
         public static string buildSignature(Type type)
         {
             string signature = "";
             if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
-            {
                 signature += "a" + buildSignature(type.GenericTypeArguments[0]);
-            }
             else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
-            {
-                signature += "a{" + buildSignature(type.GenericTypeArguments[0])
-                                      + buildSignature(type.GenericTypeArguments[1])
-                                      + "}";
-            }
+                signature += "a{" + buildSignature(type.GenericTypeArguments[0]) +
+                    buildSignature(type.GenericTypeArguments[1]) +
+                    "}";
             else
-            {
                 signature += SignatureString.For[type];
-            }
-
             return signature;
         }
 
         private static string dictionaryKeyStep(Type type, StringBuilder encoders, string parameterName ,string parameter = "", string resultParameter = "", int level = 0)
         {
             string signature = "";
-
             if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
             {
                 encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") => 
             {
                 foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Key) 
-                {
-                ");
+                {");
                 signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName , parameter + "_e", resultParameter + "_e", level + 1);
-                encoders.AppendLine(@"
+                encoders.Append(@"
                 }
             });");
             }
@@ -101,12 +90,11 @@ namespace Dbus.CodeGenerator
             {
                 foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Key) 
                 {
-                    global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);
-                                            ");
+                    global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);");
                 signature += "a{" + dictionaryKeyStep(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
                                       + dictionaryValueStep(type.GenericTypeArguments[1], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
                                       + "}";
-                encoders.AppendLine(@"
+                encoders.Append(@"
                 }
             }, true);");
             }
@@ -114,19 +102,21 @@ namespace Dbus.CodeGenerator
             {
                 signature += SignatureString.For[type];
                 if (level > 0)
-                    encoders.AppendLine(@"
+                    encoders.Append(@"
                     global::Dbus.Encoder.AddVariant(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ".Key);");
                 else
-                    encoders.AppendLine("global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
+                    encoders.Append(@"
+            global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
             }
             else
             {
                 signature += SignatureString.For[type];
                 if (level > 0)
-                    encoders.AppendLine(@"
+                    encoders.Append(@"
                     global::Dbus.Encoder.Add(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ".Key);");
                 else
-                    encoders.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
+                    encoders.Append(@"
+            global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
             }
 
             return signature;
@@ -135,16 +125,14 @@ namespace Dbus.CodeGenerator
         private static string dictionaryValueStep(Type type, StringBuilder encoders, string parameterName, string parameter = "", string resultParameter = "", int level = 0)
         {
             string signature = "";
-
             if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
             {
                 encoders.AppendLine("global::Dbus.Encoder.AddArray(sendBody" + parameter + ", ref sendIndex" + parameter + ", (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + ", ref int sendIndex_e" + parameter + @") => 
             {
                 foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Value) 
-                {
-                                        ");
+                {");
                 signature += "a" + buildSignature(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1);
-                encoders.AppendLine(@"
+                encoders.Append(@"
                 }
             });");
             }
@@ -154,11 +142,11 @@ namespace Dbus.CodeGenerator
             {
                 foreach (var " + parameterName + "_e" + resultParameter + " in " + parameterName + resultParameter + @".Value) 
                 {
-                   global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);");
+                    global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);");
                 signature += "a{" + dictionaryKeyStep(type.GenericTypeArguments[0], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
                                       + dictionaryValueStep(type.GenericTypeArguments[1], encoders, parameterName, parameter + "_e", resultParameter + "_e", level + 1)
                                       + "}";
-                encoders.AppendLine(@"
+                encoders.Append(@"
                 }
             }, true);");
             }
@@ -169,20 +157,20 @@ namespace Dbus.CodeGenerator
                     encoders.AppendLine(@"
                     global::Dbus.Encoder.AddVariant(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ".Value);");
                 else
-                    encoders.AppendLine("global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
+                    encoders.AppendLine(@"
+            global::Dbus.Encoder.AddVariant(sendBody, ref sendIndex, " + parameterName + ");");
             }
             else
             {
                 signature += SignatureString.For[type];
                 if (level > 0)
-                    encoders.AppendLine(@"
+                    encoders.Append(@"
                     global::Dbus.Encoder.Add(sendBody" + parameter + ", ref sendIndex" + parameter + ", " + parameterName + resultParameter + ".Value);");
                 else
-                    encoders.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
+                    encoders.Append(@"
+            global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameterName + ");");
             }
-
             return signature;
         }
-
     }
 }

--- a/src/Dbus.CodeGenerator/Generator.MethodImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.MethodImplementation.cs
@@ -55,8 +55,13 @@ namespace Dbus.CodeGenerator
                     foreach (var parameter in parameters)
                     {
                         encoder.Append(Indent);
-                        encoder.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameter.Name + ");");
-                        encoderSignature += SignatureString.For[parameter.ParameterType];
+                        if (parameter.ParameterType.FullName.StartsWith("System.Collections.Generic.IEnumerable") || parameter.ParameterType.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+                            encoderSignature += EncoderGenerator.buildSignature(parameter.ParameterType, encoder, parameterName: parameter.Name);
+                        else
+                        {
+                            encoderSignature += SignatureString.For[parameter.ParameterType];
+                            encoder.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameter.Name + ");");
+                        }
                     }
                 else
                     foreach (var parameter in parameters)

--- a/src/Dbus.CodeGenerator/Generator.MethodImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.MethodImplementation.cs
@@ -54,14 +54,7 @@ namespace Dbus.CodeGenerator
                 if (!isProperty)
                     foreach (var parameter in parameters)
                     {
-                        encoder.Append(Indent);
-                        if (parameter.ParameterType.FullName.StartsWith("System.Collections.Generic.IEnumerable") || parameter.ParameterType.FullName.StartsWith("System.Collections.Generic.IDictionary"))
-                            encoderSignature += EncoderGenerator.buildSignature(parameter.ParameterType, encoder, parameterName: parameter.Name);
-                        else
-                        {
-                            encoderSignature += SignatureString.For[parameter.ParameterType];
-                            encoder.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, " + parameter.Name + ");");
-                        }
+                        encoderSignature += EncoderGenerator.buildSignature(parameter.ParameterType, encoder, parameterName: parameter.Name);
                     }
                 else
                     foreach (var parameter in parameters)

--- a/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
@@ -11,7 +11,7 @@ namespace Dbus.CodeGenerator
     {
         private static string generatePropertyEncodeImplementation(Type type)
         {
-            StringBuilder propertyEncoder = new StringBuilder();
+            var propertyEncoder = new StringBuilder();
             propertyEncoder.Append(@"
         public void EncodeProperties (global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex)
         {
@@ -51,6 +51,7 @@ namespace Dbus.CodeGenerator
             foreach (var property in type.GetTypeInfo().GetProperties())
             {
                 propertyEncoder.Append(@"
+
         private void Encode" + property.Name + @"(global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex)
         {
             global::Dbus.Encoder.Add(sendBody, ref sendIndex, (global::Dbus.Signature)""" + createVariantSignature(property.PropertyType) + @""" );");

--- a/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
@@ -16,16 +16,14 @@ namespace Dbus.CodeGenerator
         public void EncodeProperties (global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex)
         {
             global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e, ref int sendIndex_e) =>
-            {
-                ");
+            {");
 
             foreach (var property in type.GetTypeInfo().GetProperties())
             {
-                propertyEncoder.Append(@"   global::Dbus.Encoder.EnsureAlignment(sendBody_e, ref sendIndex_e, 8);
+                propertyEncoder.Append(@"
+                global::Dbus.Encoder.EnsureAlignment(sendBody_e, ref sendIndex_e, 8);
                 global::Dbus.Encoder.Add(sendBody_e, ref sendIndex_e, """ + property.Name + @""" );
-                Encode" + property.Name + @"(sendBody_e, ref sendIndex_e);
-            ");
-
+                Encode" + property.Name + @"(sendBody_e, ref sendIndex_e);");
             }
             propertyEncoder.Append(@"
             }, true);
@@ -38,10 +36,10 @@ namespace Dbus.CodeGenerator
                 ");
             foreach (var property in type.GetTypeInfo().GetProperties())
             {
-                propertyEncoder.Append(@"case """ + property.Name + @""":
+                propertyEncoder.Append(@"
+                case """ + property.Name + @""":
                     Encode" + property.Name + @"(sendBody, ref sendIndex);
-                    break;
-                ");
+                    break;");
             }
             propertyEncoder.Append(@"
                 default:
@@ -50,18 +48,17 @@ namespace Dbus.CodeGenerator
                         ""No such Property: "" + requestedProperty
                     );
             }
-        }
-");
+        }");
             foreach (var property in type.GetTypeInfo().GetProperties())
             {
                 propertyEncoder.Append(@"
         private void Encode" + property.Name + @"(global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex)
         {
-            global::Dbus.Encoder.Add(sendBody, ref sendIndex, (global::Dbus.Signature)""" + createVariantSignature(property.PropertyType) + @""" );
-            ");
+            global::Dbus.Encoder.Add(sendBody, ref sendIndex, (global::Dbus.Signature)""" + createVariantSignature(property.PropertyType) + @""" );");
                 if (property.PropertyType.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
                 {
-                    propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e, ref int sendIndex_e) =>
+                    propertyEncoder.Append(@"
+            global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e, ref int sendIndex_e) =>
             {
                 foreach(var " + property.Name + @"_e in target." + property.Name + @")
                 {");
@@ -90,7 +87,8 @@ namespace Dbus.CodeGenerator
                 //}
                 else
                 {
-                    propertyEncoder.Append(@"global::Dbus.Encoder.Add(sendBody, ref sendIndex, target." + property.Name + @" );");
+                    propertyEncoder.Append(@"
+            global::Dbus.Encoder.Add(sendBody, ref sendIndex, target." + property.Name + @" );");
                 }
                 propertyEncoder.Append(@"
         }");
@@ -139,7 +137,7 @@ namespace Dbus.CodeGenerator
             if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
             {
                 propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
-                    {\n
+                    {
                     foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @")
                       {");
                 generateEnumerableEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
@@ -149,7 +147,7 @@ namespace Dbus.CodeGenerator
             else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
             {
                 propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
-                    {\n
+                    {
                     foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @")
                       {{" +
                   "global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);
@@ -176,7 +174,7 @@ namespace Dbus.CodeGenerator
             if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
             {
                 propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
-                    {\n
+                    {
                     foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @".Key)
                       {");
                 generateEnumerableEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
@@ -186,7 +184,7 @@ namespace Dbus.CodeGenerator
             else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
             {
                 propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
-                    {\n
+                    {
                     foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @".Key)
                       {{" +
                   "global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);
@@ -213,7 +211,7 @@ namespace Dbus.CodeGenerator
             if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
             {
                 propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
-                    {\n
+                    {
                     foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @".Value)
                       {");
                 generateEnumerableEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
@@ -223,7 +221,7 @@ namespace Dbus.CodeGenerator
             else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
             {
                 propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
-                    {\n
+                    {
                     foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @".Value)
                       {{" +
                   "global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);

--- a/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
@@ -80,10 +80,6 @@ namespace Dbus.CodeGenerator
                 }
             });");
                 }
-                //else if (property.GetType() == typeof(object))
-                //{
-                //    propertyEncoder.Append(@"global::Dbus.Encoder.AddVariant(sendBody_e, ref sendIndex_e," + property.Name + " );");
-                //}
                 else
                 {
                     propertyEncoder.Append(@"
@@ -93,25 +89,6 @@ namespace Dbus.CodeGenerator
         }");
             }
             return propertyEncoder.ToString();
-        }
-
-
-        //Wird nicht mehr verwendet
-        private static string createParameterDefinition(Type type)
-        {
-            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
-            {
-                return "global::System.Collections.Generic.IEnumerable<" + createParameterDefinition(type.GenericTypeArguments[0]) + ">";
-            }
-            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
-            {
-                return "global::System.Collections.Generic.IDictionary<" + createParameterDefinition(type.GenericTypeArguments[0]) + "," +
-                              createParameterDefinition(type.GenericTypeArguments[1]) + ">";
-            }
-            else
-            {
-                return type.FullName;
-            }
         }
 
         private static string createVariantSignature(Type type)
@@ -156,10 +133,6 @@ namespace Dbus.CodeGenerator
                 propertyEncoder.Append(@"}});
 ");
             }
-            //else if (property.GetType() == typeof(object))
-            //{
-            //    propertyEncoder.Append(@"global::Dbus.Encoder.AddVariant(sendBody_e, ref sendIndex_e," + property.Name + " );");
-            //}
             else
             {
                 propertyEncoder.Append(@"
@@ -193,10 +166,6 @@ namespace Dbus.CodeGenerator
                 propertyEncoder.Append(@"}});
 ");
             }
-            //else if (property.GetType() == typeof(object))
-            //{
-            //    propertyEncoder.Append(@"global::Dbus.Encoder.AddVariant(sendBody_e, ref sendIndex_e," + property.Name + " );");
-            //}
             else
             {
                 propertyEncoder.Append(@"
@@ -230,10 +199,6 @@ namespace Dbus.CodeGenerator
                 propertyEncoder.Append(@"}});
 ");
             }
-            //else if (property.GetType() == typeof(object))
-            //{
-            //    propertyEncoder.Append(@"global::Dbus.Encoder.AddVariant(sendBody_e, ref sendIndex_e," + property.Name + " );");
-            //}
             else
             {
                 propertyEncoder.Append(@"

--- a/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
@@ -29,11 +29,10 @@ namespace Dbus.CodeGenerator
             }, true);
         }
 
-        public void EncodeProperty (global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex, string requestedProperty)
+        public void EncodeProperty (global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex, string propertyName)
         {
-            switch(requestedProperty)
-            {
-                ");
+            switch(propertyName)
+            {");
             foreach (var property in type.GetTypeInfo().GetProperties())
             {
                 propertyEncoder.Append(@"
@@ -45,7 +44,7 @@ namespace Dbus.CodeGenerator
                 default:
                     throw new global::Dbus.DbusException(
                         global::Dbus.DbusException.CreateErrorName(""UnknownProperty""),
-                        ""No such Property: "" + requestedProperty
+                        ""No such Property: "" + propertyName
                     );
             }
         }");

--- a/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.PropertyEncodeImplementation.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dbus.CodeGenerator
+{
+    public static partial class Generator
+    {
+        private static string generatePropertyEncodeImplementation(Type type)
+        {
+            StringBuilder propertyEncoder = new StringBuilder();
+            propertyEncoder.Append(@"
+        public void EncodeProperties (global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex)
+        {
+            global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e, ref int sendIndex_e) =>
+            {
+                ");
+
+            foreach (var property in type.GetTypeInfo().GetProperties())
+            {
+                propertyEncoder.Append(@"   global::Dbus.Encoder.EnsureAlignment(sendBody_e, ref sendIndex_e, 8);
+                global::Dbus.Encoder.Add(sendBody_e, ref sendIndex_e, """ + property.Name + @""" );
+                Encode" + property.Name + @"(sendBody_e, ref sendIndex_e);
+            ");
+
+            }
+            propertyEncoder.Append(@"
+            }, true);
+        }
+
+        public void EncodeProperty (global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex, string requestedProperty)
+        {
+            switch(requestedProperty)
+            {
+                ");
+            foreach (var property in type.GetTypeInfo().GetProperties())
+            {
+                propertyEncoder.Append(@"case """ + property.Name + @""":
+                    Encode" + property.Name + @"(sendBody, ref sendIndex);
+                    break;
+                ");
+            }
+            propertyEncoder.Append(@"
+                default:
+                    throw new global::Dbus.DbusException(
+                        global::Dbus.DbusException.CreateErrorName(""UnknownProperty""),
+                        ""No such Property: "" + requestedProperty
+                    );
+            }
+        }
+");
+            foreach (var property in type.GetTypeInfo().GetProperties())
+            {
+                propertyEncoder.Append(@"
+        private void Encode" + property.Name + @"(global::System.Collections.Generic.List<byte> sendBody, ref int sendIndex)
+        {
+            global::Dbus.Encoder.Add(sendBody, ref sendIndex, (global::Dbus.Signature)""" + createVariantSignature(property.PropertyType) + @""" );
+            ");
+                if (property.PropertyType.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+                {
+                    propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e, ref int sendIndex_e) =>
+            {
+                foreach(var " + property.Name + @"_e in target." + property.Name + @")
+                {");
+                    generateEnumerableEncoding(propertyEncoder, property.PropertyType.GenericTypeArguments[0], "_e", property);
+                    propertyEncoder.Append(@"
+                }
+            });");
+                }
+                else if (property.PropertyType.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+                {
+                    propertyEncoder.Append(@"
+            global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e, ref int sendIndex_e ) =>
+            {
+                foreach(var " + property.Name + @"_e in target." + property.Name + @")
+                {
+                    global::Dbus.Encoder.EnsureAlignment(sendBody_e, ref sendIndex_e, 8);");
+                    generateKeyEncoding(propertyEncoder, property.PropertyType.GenericTypeArguments[0], "_e", property);
+                    generateValueEncoding(propertyEncoder, property.PropertyType.GenericTypeArguments[1], "_e", property);
+                    propertyEncoder.Append(@"
+                }
+            });");
+                }
+                //else if (property.GetType() == typeof(object))
+                //{
+                //    propertyEncoder.Append(@"global::Dbus.Encoder.AddVariant(sendBody_e, ref sendIndex_e," + property.Name + " );");
+                //}
+                else
+                {
+                    propertyEncoder.Append(@"global::Dbus.Encoder.Add(sendBody, ref sendIndex, target." + property.Name + @" );");
+                }
+                propertyEncoder.Append(@"
+        }");
+            }
+            return propertyEncoder.ToString();
+        }
+
+
+        //Wird nicht mehr verwendet
+        private static string createParameterDefinition(Type type)
+        {
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                return "global::System.Collections.Generic.IEnumerable<" + createParameterDefinition(type.GenericTypeArguments[0]) + ">";
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                return "global::System.Collections.Generic.IDictionary<" + createParameterDefinition(type.GenericTypeArguments[0]) + "," +
+                              createParameterDefinition(type.GenericTypeArguments[1]) + ">";
+            }
+            else
+            {
+                return type.FullName;
+            }
+        }
+
+        private static string createVariantSignature(Type type)
+        {
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                return "a" + createVariantSignature(type.GenericTypeArguments[0]);
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                return "a{" + createVariantSignature(type.GenericTypeArguments[0]) +
+                              createVariantSignature(type.GenericTypeArguments[1]) + "}";
+            }
+            else
+            {
+                return SignatureString.For[type];
+            }
+        }
+
+        private static void generateEnumerableEncoding(StringBuilder propertyEncoder, Type type, string parameter, PropertyInfo property, string propertyParameter = "_e")
+        {
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
+                    {\n
+                    foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @")
+                      {");
+                generateEnumerableEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
+                propertyEncoder.Append(@"}});
+");
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
+                    {\n
+                    foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @")
+                      {{" +
+                  "global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);
+");
+                generateKeyEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
+                generateValueEncoding(propertyEncoder, type.GenericTypeArguments[1], parameter + "_e", property, propertyParameter + "_e");
+                propertyEncoder.Append(@"}});
+");
+            }
+            //else if (property.GetType() == typeof(object))
+            //{
+            //    propertyEncoder.Append(@"global::Dbus.Encoder.AddVariant(sendBody_e, ref sendIndex_e," + property.Name + " );");
+            //}
+            else
+            {
+                propertyEncoder.Append(@"
+                global::Dbus.Encoder.Add(sendBody" + parameter + @", ref sendIndex" + parameter + @"," + property.Name + propertyParameter + @" );
+");
+            }
+        }
+
+        private static void generateKeyEncoding(StringBuilder propertyEncoder, Type type, string parameter, PropertyInfo property, string propertyParameter = "_e")
+        {
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
+                    {\n
+                    foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @".Key)
+                      {");
+                generateEnumerableEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
+                propertyEncoder.Append(@"}});
+");
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
+                    {\n
+                    foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @".Key)
+                      {{" +
+                  "global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);
+");
+                generateKeyEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
+                generateValueEncoding(propertyEncoder, type.GenericTypeArguments[1], parameter + "_e", property, propertyParameter + "_e");
+                propertyEncoder.Append(@"}});
+");
+            }
+            //else if (property.GetType() == typeof(object))
+            //{
+            //    propertyEncoder.Append(@"global::Dbus.Encoder.AddVariant(sendBody_e, ref sendIndex_e," + property.Name + " );");
+            //}
+            else
+            {
+                propertyEncoder.Append(@"
+                global::Dbus.Encoder.Add(sendBody" + parameter + @", ref sendIndex" + parameter + @"," + property.Name + propertyParameter + @".Key );
+");
+            }
+        }
+
+        private static void generateValueEncoding(StringBuilder propertyEncoder, Type type, string parameter, PropertyInfo property, string propertyParameter = "_e")
+        {
+            if (type.FullName.StartsWith("System.Collections.Generic.IEnumerable"))
+            {
+                propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
+                    {\n
+                    foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @".Value)
+                      {");
+                generateEnumerableEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
+                propertyEncoder.Append(@"}});
+");
+            }
+            else if (type.FullName.StartsWith("System.Collections.Generic.IDictionary"))
+            {
+                propertyEncoder.Append(@"global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e" + parameter + @", ref int sendIndex_e" + parameter + @") =>
+                    {\n
+                    foreach(var " + property.Name + "_e" + parameter + @" in " + property.Name + parameter + @".Value)
+                      {{" +
+                  "global::Dbus.Encoder.EnsureAlignment(sendBody_e" + parameter + ", ref sendIndex_e" + parameter + @", 8);
+");
+                generateKeyEncoding(propertyEncoder, type.GenericTypeArguments[0], parameter + "_e", property, propertyParameter + "_e");
+                generateValueEncoding(propertyEncoder, type.GenericTypeArguments[1], parameter + "_e", property, propertyParameter + "_e");
+                propertyEncoder.Append(@"}});
+");
+            }
+            //else if (property.GetType() == typeof(object))
+            //{
+            //    propertyEncoder.Append(@"global::Dbus.Encoder.AddVariant(sendBody_e, ref sendIndex_e," + property.Name + " );");
+            //}
+            else
+            {
+                propertyEncoder.Append(@"
+                global::Dbus.Encoder.Add(sendBody" + parameter + @", ref sendIndex" + parameter + @"," + property.Name + propertyParameter + @".Value );
+");
+            }
+        }
+    }
+}

--- a/src/Dbus.CodeGenerator/Generator.ProxyImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.ProxyImplementation.cs
@@ -13,7 +13,7 @@ namespace Dbus.CodeGenerator
             if (!method.Name.EndsWith("Async"))
                 throw new InvalidOperationException("Only method names ending in 'Async' are supported");
             if (method.ReturnType != typeof(Task) && method.ReturnType.GetGenericTypeDefinition() != typeof(Task<>))
-                throw new InvalidOperationException("Only methods returning a Tak type are supported");
+                throw new InvalidOperationException("Only methods returning a Task type are supported");
 
             var methodName = method.Name.Substring(0, method.Name.Length - "Async".Length);
             var methodImplementation = new StringBuilder();

--- a/src/Dbus.CodeGenerator/Generator.ProxyImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.ProxyImplementation.cs
@@ -49,9 +49,8 @@ namespace Dbus.CodeGenerator
                 }
                 else
                 {
-                    sendSignature += SignatureString.For[returnType];
                     encoders.Append(Indent);
-                    encoders.AppendLine("global::Dbus.Encoder.Add(sendBody, ref sendIndex, result);");
+                    sendSignature += EncoderGenerator.buildSignature(returnType, encoders);
                 }
             }
 

--- a/src/Dbus.CodeGenerator/Generator.ProxyImplementation.cs
+++ b/src/Dbus.CodeGenerator/Generator.ProxyImplementation.cs
@@ -64,7 +64,7 @@ namespace Dbus.CodeGenerator
             methodImplementation.AppendLine(@").ConfigureAwait(false);
 ");
             methodImplementation.Append(Indent);
-            methodImplementation.AppendLine(@" if (shouldSendReply)
+            methodImplementation.AppendLine(@"if (shouldSendReply)
             {");
             methodImplementation.Append(Indent);
             methodImplementation.AppendLine("var sendBody = global::Dbus.Encoder.StartNew();");
@@ -73,7 +73,7 @@ namespace Dbus.CodeGenerator
             methodImplementation.Append(Indent);
             methodImplementation.Append(@"await connection.SendMethodReturnAsync(replySerial, header.Sender, sendBody, """ + sendSignature + @""").ConfigureAwait(false);");
             methodImplementation.AppendLine(@"
-        }");
+            }");
             methodImplementation.AppendLine(@"
         }");
 

--- a/src/Dbus.CodeGenerator/Generator.cs
+++ b/src/Dbus.CodeGenerator/Generator.cs
@@ -89,7 +89,7 @@ namespace Dbus.CodeGenerator
             if (!typeof(IDisposable).GetTypeInfo().IsAssignableFrom(type))
                 throw new InvalidOperationException("The interface " + type.Name + " is meant to be consumed, but does not extend IDisposable");
 
-            var className = type.Name.Substring(1);
+            var className = type.Name + "_Implementation";
             var eventSubscriptions = new StringBuilder();
             var methodImplementations = new StringBuilder();
             var eventImplementations = new StringBuilder();

--- a/src/Dbus.CodeGenerator/Generator.cs
+++ b/src/Dbus.CodeGenerator/Generator.cs
@@ -54,7 +54,7 @@ namespace Dbus.CodeGenerator
     {
         static partial void DoInit()
         {
-            global::Dbus.Connection.AddPublishProxy<Dbus.IOrgFreedesktopDbusObjectManagerProvide>(Dbus.OrgFreedesktopDbusObjectManager_Proxy.Factory);
+            global::Dbus.Connection.AddPublishProxy<global::Dbus.IOrgFreedesktopDbusObjectManagerProvide>(global::Dbus.OrgFreedesktopDbusObjectManager_Proxy.Factory);
             " + string.Join(@"
             ", registrations) + @"
         }

--- a/src/Dbus.CodeGenerator/Generator.cs
+++ b/src/Dbus.CodeGenerator/Generator.cs
@@ -248,7 +248,7 @@ namespace Dbus.CodeGenerator
     public sealed class " + type.Name + @"_Proxy : global::System.IDisposable, global::Dbus.IProxy
     {
 
-        public string interfaceName { get; }
+        public string InterfaceName { get; }
 
         private readonly global::Dbus.Connection connection;
         private readonly " + BuildTypeString(type) + @" target;
@@ -261,10 +261,10 @@ namespace Dbus.CodeGenerator
             this.connection = connection;
             this.target = target;
             this.path = path;
-            interfaceName = """ + provide.InterfaceName + @""";
+            InterfaceName = """ + provide.InterfaceName + @""";
             registration = connection.RegisterObjectProxy(
                 path ?? """ + provide.Path + @""",
-                interfaceName,
+                InterfaceName,
                 this
             );");
 

--- a/src/Dbus.CodeGenerator/Generator.cs
+++ b/src/Dbus.CodeGenerator/Generator.cs
@@ -288,7 +288,7 @@ namespace Dbus.CodeGenerator
                 var sendBody = global::Dbus.Encoder.StartNew();
                 var sendIndex = 0;
                 global::Dbus.Encoder.Add(sendBody, ref sendIndex, """ + provide.InterfaceName + @""");");
-                //Nur eine Property wird jeweils verändert: keine foreach-Schleife notwendig
+                //Only one property is changed at a time, so no foreach loop is necessary
                 proxyClass.Append(@"
                 global::Dbus.Encoder.AddArray(sendBody, ref sendIndex, (global::System.Collections.Generic.List<byte> sendBody_e, ref int sendIndex_e) =>
                 {
@@ -312,7 +312,7 @@ namespace Dbus.CodeGenerator
                                 throw new System.NotSupportedException(""Property encoding not supported for the given property"" + e.PropertyName);
                         }
                 }, true);");
-                //Eigentlich ein leeres Array, die Implementierung über einen Integer mit Wert 0 ist effizienter
+                //This is actually an empty array, but the encoding per 0-integer is more efficient
                 proxyClass.Append(@"
                 global::Dbus.Encoder.Add(sendBody, ref sendIndex, 0);
 

--- a/src/Dbus.CodeGenerator/Generator.cs
+++ b/src/Dbus.CodeGenerator/Generator.cs
@@ -81,7 +81,6 @@ namespace Dbus.CodeGenerator
         }
     }
 ";
-
             return initClass + result.ToString();
         }
 
@@ -267,9 +266,7 @@ namespace Dbus.CodeGenerator
                 path ?? """ + provide.Path + @""",
                 interfaceName,
                 this
-            );
-
-");
+            );");
 
             if (typeof(System.ComponentModel.INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
                 proxyClass.Append(@"
@@ -277,13 +274,12 @@ namespace Dbus.CodeGenerator
             target.PropertyChanged += HandlePropertyChangedEventAsync;");
 
             proxyClass.Append(@"
-    }
+        }
 
         public static " + type.Name + @"_Proxy Factory(global::Dbus.Connection connection, " + type.FullName + @" target, global::Dbus.ObjectPath path)
         {
             return new " + type.Name + @"_Proxy(connection, target, path);
-        }
-");
+        }");
             if (typeof(System.ComponentModel.INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
             {
                 proxyClass.Append(@"
@@ -310,7 +306,6 @@ namespace Dbus.CodeGenerator
                                 break;
 ");
                     }
-
                 }
                 proxyClass.Append(@"
                             default:
@@ -328,10 +323,7 @@ namespace Dbus.CodeGenerator
                     sendBody,
                     ""sa{sv}as""
                 );
-            }
-
-            ");
-
+            }");
             }
             proxyClass.Append(@"
 "
@@ -369,7 +361,6 @@ namespace Dbus.CodeGenerator
         }
     }
 ");
-
             return Tuple.Create(proxyClass.ToString(), proxyRegistration);
         }
 

--- a/src/Dbus.CodeGenerator/Generator.cs
+++ b/src/Dbus.CodeGenerator/Generator.cs
@@ -54,6 +54,7 @@ namespace Dbus.CodeGenerator
     {
         static partial void DoInit()
         {
+            global::Dbus.Connection.AddPublishProxy<Dbus.IOrgFreedesktopDbusObjectManagerProvide>(Dbus.OrgFreedesktopDbusObjectManager_Proxy.Factory);
             " + string.Join(@"
             ", registrations) + @"
         }

--- a/src/Dbus.CodeGenerator/Generator.cs
+++ b/src/Dbus.CodeGenerator/Generator.cs
@@ -316,13 +316,13 @@ namespace Dbus.CodeGenerator
                 proxyClass.Append(@"
                 global::Dbus.Encoder.Add(sendBody, ref sendIndex, 0);
 
-                    await connection.SendSignal(
+                await connection.SendSignalAsync(
                     path,
                     ""org.freedesktop.DBus.Properties"",
                     ""PropertiesChanged"",
                     sendBody,
                     ""sa{sv}as""
-                );
+                ).ConfigureAwait(false);
             }");
             }
             proxyClass.Append(@"

--- a/src/Dbus.CodeGenerator/Generator.cs
+++ b/src/Dbus.CodeGenerator/Generator.cs
@@ -245,7 +245,7 @@ namespace Dbus.CodeGenerator
 
             var proxyRegistration = "global::Dbus.Connection.AddPublishProxy<" + BuildTypeString(type) + ">(" + type.Name + "_Proxy.Factory);";
             StringBuilder proxyClass = new StringBuilder(@"
-    public sealed class " + type.Name + @"_Proxy : global::System.IDisposable, global::Dbus.IProxy
+    public sealed class " + type.Name + @"_Proxy : global::Dbus.IProxy
     {
 
         public string InterfaceName { get; }

--- a/src/Dbus/Connection.cs
+++ b/src/Dbus/Connection.cs
@@ -430,6 +430,7 @@ namespace Dbus
             {
                 Task.Run(() =>
                     handlePropertyRequestAsync(replySerial, header, body));
+                    return;
             }
             var dictionaryEntry = header.Path + "\0" + header.InterfaceName;
             if (objectProxies.TryGetValue(dictionaryEntry, out var proxy))

--- a/src/Dbus/Connection.cs
+++ b/src/Dbus/Connection.cs
@@ -219,8 +219,12 @@ namespace Dbus
             Signature signature
             )
         {
-            if (path.ToString() == "" || interfaceName == "" || methodName == "")
-                throw new InvalidOperationException("Signal path, interface and member must not be empty!");
+            if (path.ToString() == "")
+                throw new ArgumentException("Signal path must not be empty", nameof(path));
+            if (interfaceName == "")
+                throw new ArgumentException("Signal interface must not be empty", nameof(interfaceName));
+            if (methodName == "")
+                throw new ArgumentException("Signal member must not be empty", nameof(methodName));
 
             var serial = Interlocked.Increment(ref serialCounter);
             var message = Encoder.StartNew();
@@ -430,7 +434,7 @@ namespace Dbus
             {
                 Task.Run(() =>
                     handlePropertyRequestAsync(replySerial, header, body));
-                    return;
+                return;
             }
             var dictionaryEntry = header.Path + "\0" + header.InterfaceName;
             if (objectProxies.TryGetValue(dictionaryEntry, out var proxy))

--- a/src/Dbus/Connection.cs
+++ b/src/Dbus/Connection.cs
@@ -245,13 +245,8 @@ namespace Dbus
             });
             Encoder.EnsureAlignment(message, ref index, 8);
             message.AddRange(body);
-
-            //var tcs = new TaskCompletionSource<ReceivedMethodReturn>();
-            //expectedMessages[(uint)serial] = tcs;
-
             var messageArray = message.ToArray();
             await SerializedWriteToStream(messageArray);
-            //return await tcs.Task.ConfigureAwait(false);
         }
 
         public async Task SendMethodReturnAsync(uint replySerial, string destination, List<byte> body, Signature signature)

--- a/src/Dbus/Connection.cs
+++ b/src/Dbus/Connection.cs
@@ -103,8 +103,7 @@ namespace Dbus
             {
                 Deregister = () =>
                 {
-                    IProxy _;
-                    objectProxies.TryRemove(dictionaryEntry, out _);
+                    objectProxies.TryRemove(dictionaryEntry, out var _);
                 }
             };
         }
@@ -221,9 +220,7 @@ namespace Dbus
             )
         {
             if (path.ToString() == "" || interfaceName == "" || methodName == "")
-            {
                 throw new InvalidOperationException("Signal path, interface and member must not be empty!");
-            }
 
             var serial = Interlocked.Increment(ref serialCounter);
             var message = Encoder.StartNew();

--- a/src/Dbus/DBusPropertiesChanged.cs
+++ b/src/Dbus/DBusPropertiesChanged.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Dbus
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DbusPropertiesChanged : Attribute
+    {
+    }
+}

--- a/src/Dbus/Dbus.csproj
+++ b/src/Dbus/Dbus.csproj
@@ -17,6 +17,10 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <DefineConstants>$(DefineConstants);FULL_FRAMEWORK</DefineConstants>
   </PropertyGroup>

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -99,13 +99,13 @@ namespace Dbus
             Add(buffer, ref index, value ? 1 : 0);
         }
 
-  
+
         public static void AddArray(List<byte> buffer, ref int index, ElementWriter writer, Boolean alignment_8 = false)
         {
             EnsureAlignment(buffer, ref index, 4);
             var lengthPosition = index;
             Add(buffer, ref index, 0); // Actually uint
-            EnsureAlignment(buffer, ref index, alignment_8?8:4);
+            EnsureAlignment(buffer, ref index, alignment_8 ? 8 : 4);
             var arrayStart = index;
             writer(buffer, ref index);
             var arrayLength = index - arrayStart;
@@ -113,7 +113,7 @@ namespace Dbus
             for (var i = 0; i < 4; ++i)
                 buffer[lengthPosition + i] = lengthBytes[i];
         }
-        
+
 
         public static void AddVariant(List<byte> buffer, ref int index, string value)
         {

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -99,16 +99,27 @@ namespace Dbus
             Add(buffer, ref index, value ? 1 : 0);
         }
 
-        public static void AddArray(List<byte> buffer, ref int index, ElementWriter writer)
+  
+        public static void AddArray(List<byte> buffer, ref int index, ElementWriter writer, Boolean alignment_8 = false)
         {
+            int alignment;
+            if (alignment_8)
+                alignment = 8;
+            else
+                alignment = 4;
+            EnsureAlignment(buffer, ref index, 4);
             var lengthPosition = index;
             Add(buffer, ref index, 0); // Actually uint
+            EnsureAlignment(buffer, ref index, alignment);
+            var arrayStart = index;
             writer(buffer, ref index);
-            var arrayLength = index - (lengthPosition + 4);
+            var arrayLength = index - arrayStart;
             var lengthBytes = BitConverter.GetBytes(arrayLength);
             for (var i = 0; i < 4; ++i)
                 buffer[lengthPosition + i] = lengthBytes[i];
+            
         }
+        
 
         public static void AddVariant(List<byte> buffer, ref int index, string value)
         {

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -145,6 +145,76 @@ namespace Dbus
             Add(buffer, ref index, signature);
         }
 
+        public static void AddVariant(List<byte> buffer, ref int index, object value)
+        {
+            switch (value)
+            {
+                case bool v:
+                    Add(buffer, ref index, (Signature)"b");
+                    Add(buffer, ref index, v);
+                    break;
+                case string v:
+                    AddVariant(buffer, ref index, v);
+                    break;
+                case ObjectPath v:
+                    AddVariant(buffer, ref index, v);
+                    break;
+                case uint v:
+                    AddVariant(buffer, ref index, v);
+                    break;
+                case Signature v:
+                    AddVariant(buffer, ref index, v);
+                    break;
+                case IEnumerable<ObjectPath> v:
+                    Add(buffer, ref index, (Signature)"ao");
+                    AddArray(buffer, ref index, (global::System.Collections.Generic.List<byte> buffer_e, ref int index_e) =>
+                    {
+                        foreach (var element in v)
+                        {
+                            Add(buffer_e, ref index_e, element);
+                        }
+                    });
+                    break;
+                case IEnumerable<string> v:
+                    Add(buffer, ref index, (Signature)"as");
+                    AddArray(buffer, ref index, (global::System.Collections.Generic.List<byte> buffer_e, ref int index_e) =>
+                    {
+                        foreach (var element in v)
+                        {
+                            Add(buffer_e, ref index_e, element);
+                        }
+                    });
+                    break;
+                case IEnumerable<byte> v:
+                    Add(buffer, ref index, (Signature)"ay");
+                    AddArray(buffer, ref index, (global::System.Collections.Generic.List<byte> buffer_e, ref int index_e) =>
+                    {
+                        foreach (var element in v)
+                        {
+                            Add(buffer_e, ref index_e, element);
+                        }
+                    });
+                    break;
+                default:
+                    throw new InvalidOperationException("Unsupported Type for Variant");
+            }
+        }
+
+        public static void AddVariant(List<byte> buffer, ref int index, IDictionary<string, object> value)
+        {
+            System.Console.WriteLine("Encoding Dictionary");
+            Add(buffer, ref index, (Signature)"a{sv}");
+            AddArray(buffer, ref index, (global::System.Collections.Generic.List<byte> buffer_e, ref int index_e) =>
+            {
+                foreach (var element in value)
+                {
+                    EnsureAlignment(buffer_e, ref index_e, 8);
+                    Add(buffer_e, ref index_e, element.Key);
+                    AddVariant(buffer_e, ref index_e, element.Value);
+                }
+            }, true);
+        }
+
         public static void EnsureAlignment(List<byte> buffer, ref int index, int alignment)
         {
             var bytesToAdd = Alignment.Calculate(buffer.Count, alignment);

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -173,7 +173,7 @@ namespace Dbus
         {
             System.Console.WriteLine("Encoding Dictionary");
             Add(buffer, ref index, (Signature)"a{sv}");
-            AddArray(buffer, ref index, (global::System.Collections.Generic.List<byte> buffer_e, ref int index_e) =>
+            AddArray(buffer, ref index, (List<byte> buffer_e, ref int index_e) =>
             {
                 foreach (var element in value)
                 {

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -164,36 +164,6 @@ namespace Dbus
                 case Signature v:
                     AddVariant(buffer, ref index, v);
                     break;
-                case IEnumerable<ObjectPath> v:
-                    Add(buffer, ref index, (Signature)"ao");
-                    AddArray(buffer, ref index, (global::System.Collections.Generic.List<byte> buffer_e, ref int index_e) =>
-                    {
-                        foreach (var element in v)
-                        {
-                            Add(buffer_e, ref index_e, element);
-                        }
-                    });
-                    break;
-                case IEnumerable<string> v:
-                    Add(buffer, ref index, (Signature)"as");
-                    AddArray(buffer, ref index, (global::System.Collections.Generic.List<byte> buffer_e, ref int index_e) =>
-                    {
-                        foreach (var element in v)
-                        {
-                            Add(buffer_e, ref index_e, element);
-                        }
-                    });
-                    break;
-                case IEnumerable<byte> v:
-                    Add(buffer, ref index, (Signature)"ay");
-                    AddArray(buffer, ref index, (global::System.Collections.Generic.List<byte> buffer_e, ref int index_e) =>
-                    {
-                        foreach (var element in v)
-                        {
-                            Add(buffer_e, ref index_e, element);
-                        }
-                    });
-                    break;
                 default:
                     throw new InvalidOperationException("Unsupported Type for Variant");
             }

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -139,13 +139,18 @@ namespace Dbus
             Add(buffer, ref index, signature);
         }
 
+        public static void AddVariant(List<byte> buffer, ref int index, bool value)
+        {
+            Add(buffer, ref index, (Signature)"b");
+            Add(buffer, ref index, value);
+        }
+
         public static void AddVariant(List<byte> buffer, ref int index, object value)
         {
             switch (value)
             {
                 case bool v:
-                    Add(buffer, ref index, (Signature)"b");
-                    Add(buffer, ref index, v);
+                    AddVariant(buffer, ref index, v);
                     break;
                 case string v:
                     AddVariant(buffer, ref index, v);

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -117,7 +117,6 @@ namespace Dbus
             var lengthBytes = BitConverter.GetBytes(arrayLength);
             for (var i = 0; i < 4; ++i)
                 buffer[lengthPosition + i] = lengthBytes[i];
-            
         }
         
 

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -102,15 +102,10 @@ namespace Dbus
   
         public static void AddArray(List<byte> buffer, ref int index, ElementWriter writer, Boolean alignment_8 = false)
         {
-            int alignment;
-            if (alignment_8)
-                alignment = 8;
-            else
-                alignment = 4;
             EnsureAlignment(buffer, ref index, 4);
             var lengthPosition = index;
             Add(buffer, ref index, 0); // Actually uint
-            EnsureAlignment(buffer, ref index, alignment);
+            EnsureAlignment(buffer, ref index, alignment_8?8:4);
             var arrayStart = index;
             writer(buffer, ref index);
             var arrayLength = index - arrayStart;

--- a/src/Dbus/Encoder.cs
+++ b/src/Dbus/Encoder.cs
@@ -171,7 +171,6 @@ namespace Dbus
 
         public static void AddVariant(List<byte> buffer, ref int index, IDictionary<string, object> value)
         {
-            System.Console.WriteLine("Encoding Dictionary");
             Add(buffer, ref index, (Signature)"a{sv}");
             AddArray(buffer, ref index, (List<byte> buffer_e, ref int index_e) =>
             {

--- a/src/Dbus/IOrgFreedesktopDBusObjectManagerProvide.cs
+++ b/src/Dbus/IOrgFreedesktopDBusObjectManagerProvide.cs
@@ -5,7 +5,7 @@ namespace Dbus
 {
     public interface IOrgFreedesktopDbusObjectManagerProvide
     {
-        ObjectPath root { get; }
+        ObjectPath Root { get; }
         Task<Dictionary<ObjectPath, List<IProxy>>> GetManagedObjectsAsync();
     }
 }

--- a/src/Dbus/IOrgFreedesktopDBusObjectManagerProvide.cs
+++ b/src/Dbus/IOrgFreedesktopDBusObjectManagerProvide.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dbus
+{
+    public interface IOrgFreedesktopDbusObjectManagerProvide
+    {
+        ObjectPath root { get; }
+        Task<Dictionary<ObjectPath, List<IProxy>>> GetManagedObjectsAsync();
+    }
+}

--- a/src/Dbus/IProxy.cs
+++ b/src/Dbus/IProxy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dbus
+{
+    public interface IProxy
+    {
+        string interfaceName { get; }
+        void EncodeProperties(List<byte> sendBody, ref int index);
+        Task HandleMethodCallAsync(uint replySerial, MessageHeader header, byte[] body, bool shouldSendReply);
+        void EncodeProperty(List<byte> sendBody, ref int index, string requestedProperty);
+    }
+}

--- a/src/Dbus/IProxy.cs
+++ b/src/Dbus/IProxy.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Dbus
 {
-    public interface IProxy
+    public interface IProxy : IDisposable
     {
         string InterfaceName { get; }
         void EncodeProperties(List<byte> sendBody, ref int index);

--- a/src/Dbus/IProxy.cs
+++ b/src/Dbus/IProxy.cs
@@ -8,9 +8,9 @@ namespace Dbus
 {
     public interface IProxy
     {
-        string interfaceName { get; }
+        string InterfaceName { get; }
         void EncodeProperties(List<byte> sendBody, ref int index);
         Task HandleMethodCallAsync(uint replySerial, MessageHeader header, byte[] body, bool shouldSendReply);
-        void EncodeProperty(List<byte> sendBody, ref int index, string requestedProperty);
+        void EncodeProperty(List<byte> sendBody, ref int index, string propertyName);
     }
 }

--- a/src/Dbus/OrgFreedesktopDbusObjectManager.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager.cs
@@ -47,7 +47,15 @@ namespace Dbus
             return managedObjects;
         }
 
-        public void Dispose() =>
-            throw new NotImplementedException();
+        public void Dispose()
+        {
+            foreach (var proxies in managedObjects)
+            {
+                foreach (var proxy in proxies.Value)
+                {
+                    proxy.Dispose();
+                }
+            }
+        }
     }
 }

--- a/src/Dbus/OrgFreedesktopDbusObjectManager.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dbus
+{
+    public class OrgFreedesktopDbusObjectManager : IOrgFreedesktopDbusObjectManagerProvide
+    {
+
+        public ObjectPath root { get; }
+
+        private readonly Connection connection;
+        private readonly Dictionary<ObjectPath, List<IProxy>> managedObjects;
+        //        private Dictionary<ObjectPath, IDictionary<string, IDictionary<string, object>>> managedObjects;
+
+        public OrgFreedesktopDbusObjectManager(Connection connection, ObjectPath root)
+        {
+            this.connection = connection;
+            this.root = root;
+            managedObjects = new Dictionary<ObjectPath, List<IProxy>>() { };
+        }
+
+        public event Action<ObjectPath, IDictionary<string, IDictionary<string, object>>> InterfacesAdded;
+        public event Action<ObjectPath, IEnumerable<string>> InterfacesRemoved;
+
+        public void AddObject<TInterface, TImplementation>(TImplementation instance, ObjectPath path) where TImplementation : TInterface
+        {
+            string editedPath;
+            if (path.ToString() == "/")
+                editedPath = "";
+            else
+                editedPath = path.ToString();
+            var proxy = (IProxy)connection.Publish<TInterface>(instance, root.ToString() + editedPath);
+            if (managedObjects.ContainsKey(root.ToString() + editedPath))
+            {
+                managedObjects[root.ToString() + editedPath].Add((proxy));
+            }
+            else
+            {
+                managedObjects.Add(root.ToString() + editedPath, new List<IProxy>() { (proxy) });
+            }
+        }
+
+        public async Task<Dictionary<ObjectPath, List<IProxy>>> GetManagedObjectsAsync()
+        {
+            await Task.Delay(1000);
+            return managedObjects;
+        }
+
+        public void Dispose() =>
+            throw new NotImplementedException();
+    }
+}

--- a/src/Dbus/OrgFreedesktopDbusObjectManager.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager.cs
@@ -16,8 +16,8 @@ namespace Dbus
         public OrgFreedesktopDbusObjectManager(Connection connection, ObjectPath root)
         {
             this.connection = connection;
-            managedObjects = new Dictionary<ObjectPath, List<IProxy>>() { };
             Root = root;
+            managedObjects = new Dictionary<ObjectPath, List<IProxy>>();
         }
 
         public event Action<ObjectPath, IDictionary<string, IDictionary<string, object>>> InterfacesAdded;

--- a/src/Dbus/OrgFreedesktopDbusObjectManager.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager.cs
@@ -41,20 +41,14 @@ namespace Dbus
         {
             if (!path.ToString().StartsWith("./"))
                 throw new ArgumentException("A partial path has to start with ./");
-            else
-            {
-                if (Root == "/")
-                {
-                    return path.ToString().Substring(1);
-                }
-                else
-                {
-                    if (path.ToString() == "./")
-                        return Root.ToString();
-                    else
-                        return Root + path.ToString().Substring(1);
-                }
-            }
+
+            if (Root == "/")
+                return path.ToString().Substring(1);
+
+            if (path.ToString() == "./")
+                return Root.ToString();
+            return Root + path.ToString().Substring(1);
+
         }
 
         public async Task<Dictionary<ObjectPath, List<IProxy>>> GetManagedObjectsAsync()

--- a/src/Dbus/OrgFreedesktopDbusObjectManager.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager.cs
@@ -20,8 +20,8 @@ namespace Dbus
             managedObjects = new Dictionary<ObjectPath, List<IProxy>>();
         }
 
-        public event Action<ObjectPath, IDictionary<string, IDictionary<string, object>>> InterfacesAdded;
-        public event Action<ObjectPath, IEnumerable<string>> InterfacesRemoved;
+        public event Action<ObjectPath, IDictionary<string, IDictionary<string, object>>> InterfacesAdded { add { } remove { } }
+        public event Action<ObjectPath, IEnumerable<string>> InterfacesRemoved { add { } remove { } }
 
         public void AddObject<TInterface, TImplementation>(TImplementation instance, ObjectPath path) where TImplementation : TInterface
         {

--- a/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
@@ -106,7 +106,7 @@ namespace Dbus
         }
 
 
-        private static void assertSignature(global::Dbus.Signature actual, global::Dbus.Signature expected)
+        private static void assertSignature(Signature actual, Signature expected)
         {
             if (actual != expected)
                 throw new DbusException(

--- a/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
@@ -7,7 +7,7 @@ namespace Dbus
     public sealed class OrgFreedesktopDbusObjectManager_Proxy : IDisposable, IProxy
     {
 
-        public string interfaceName { get; }
+        public string InterfaceName { get; }
 
         private readonly Connection connection;
         private readonly IOrgFreedesktopDbusObjectManagerProvide target;
@@ -20,10 +20,10 @@ namespace Dbus
             this.connection = connection;
             this.target = target;
             this.path = path;
-            interfaceName = "org.freedesktop.DBus.ObjectManager";
+            InterfaceName = "org.freedesktop.DBus.ObjectManager";
             registration = connection.RegisterObjectProxy(
                 path ?? "",
-                interfaceName,
+                InterfaceName,
                 this
             );
         }
@@ -74,7 +74,7 @@ namespace Dbus
                             foreach (var interfaceInstance in managedObject.Value)
                             {
                                 Encoder.EnsureAlignment(sendBody_e_e, ref sendIndex_e_e, 8);
-                                Encoder.Add(sendBody_e, ref sendIndex_e_e, interfaceInstance.interfaceName);
+                                Encoder.Add(sendBody_e, ref sendIndex_e_e, interfaceInstance.InterfaceName);
                                 interfaceInstance.EncodeProperties(sendBody_e_e, ref sendIndex);
                             }
                             Encoder.EnsureAlignment(sendBody_e_e, ref sendIndex_e_e, 8);

--- a/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
@@ -17,11 +17,9 @@ namespace Dbus
 
         private OrgFreedesktopDbusObjectManager_Proxy(Connection connection, IOrgFreedesktopDbusObjectManagerProvide target, ObjectPath path)
         {
-            if (path == null)
-                throw new ArgumentNullException("An ObjectManager needs a path!");
             this.connection = connection;
             this.target = target;
-            this.path = path;
+            this.path = path ?? throw new ArgumentNullException(nameof(path));
             InterfaceName = "org.freedesktop.DBus.ObjectManager";
             registration = connection.RegisterObjectProxy(
                 path,

--- a/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Dbus
 {
-    public sealed class OrgFreedesktopDbusObjectManager_Proxy : IDisposable, IProxy
+    public sealed class OrgFreedesktopDbusObjectManager_Proxy : IProxy
     {
 
         public string InterfaceName { get; }

--- a/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dbus
+{
+    public sealed class OrgFreedesktopDbusObjectManager_Proxy : IDisposable, IProxy
+    {
+
+        public string interfaceName { get; }
+
+        private readonly Connection connection;
+        private readonly IOrgFreedesktopDbusObjectManagerProvide target;
+        private readonly ObjectPath path;
+
+
+        private IDisposable registration;
+
+        private OrgFreedesktopDbusObjectManager_Proxy(Connection connection, IOrgFreedesktopDbusObjectManagerProvide target, ObjectPath path)
+        {
+            this.connection = connection;
+            this.target = target;
+            this.path = path;
+            interfaceName = "org.freedesktop.DBus.ObjectManager";
+            registration = connection.RegisterObjectProxy(
+                path ?? "",
+                interfaceName,
+                this
+            );
+        }
+
+        public static OrgFreedesktopDbusObjectManager_Proxy Factory(Connection connection, IOrgFreedesktopDbusObjectManagerProvide target, ObjectPath path)
+        {
+            return new OrgFreedesktopDbusObjectManager_Proxy(connection, target, path);
+        }
+
+        public void Encode(List<byte> sendBody, ref int sendIndex)
+
+        {
+            Encoder.AddArray(sendBody, ref sendIndex, (List<byte> sendBody_e, ref int sendIndex_e) =>
+            {
+            });
+        }
+
+        public Task HandleMethodCallAsync(uint replySerial, MessageHeader header, byte[] body, bool doNotReply)
+        {
+            switch (header.Member)
+            {
+                case "GetManagedObjects":
+                    return handleGetManagedObjectsAsync(replySerial, header, body, doNotReply);
+                default:
+                    throw new DbusException(
+                        DbusException.CreateErrorName("UnknownMethod"),
+                        "Method not supported"
+                    );
+            }
+        }
+
+        private async Task handleGetManagedObjectsAsync(uint replySerial, MessageHeader header, byte[] receivedBody, bool shouldSendReply)
+        {
+            assertSignature(header.BodySignature, "");
+            var managedObjects = await target.GetManagedObjectsAsync().ConfigureAwait(false);
+            var sendBody = Encoder.StartNew();
+            var sendIndex = 0;
+            if (shouldSendReply)
+            {
+                Encoder.AddArray(sendBody, ref sendIndex, (List<byte> sendBody_e, ref int sendIndex_e) =>
+                {
+                    foreach (var managedObject in managedObjects)
+                    {
+                        Encoder.EnsureAlignment(sendBody_e, ref sendIndex_e, 8);
+                        Encoder.Add(sendBody_e, ref sendIndex_e, managedObject.Key);
+                        Encoder.AddArray(sendBody_e, ref sendIndex_e, (List<byte> sendBody_e_e, ref int sendIndex_e_e) =>
+                        {
+                            foreach (var interfaceInstance in managedObject.Value)
+                            {
+                                Encoder.EnsureAlignment(sendBody_e_e, ref sendIndex_e_e, 8);
+                                Encoder.Add(sendBody_e, ref sendIndex_e_e, interfaceInstance.interfaceName);
+                                interfaceInstance.EncodeProperties(sendBody_e_e, ref sendIndex);
+                            }
+                            Encoder.EnsureAlignment(sendBody_e_e, ref sendIndex_e_e, 8);
+                            Encoder.Add(sendBody_e, ref sendIndex_e_e, "org.freedesktop.DBus.Properties");
+                            Encoder.AddArray(sendBody_e_e, ref sendIndex_e_e, (List<byte> sendBody_e_e_e, ref int sendIndex_e_e_e) => { }, true);
+                        }, true);
+
+                    }
+                }, true);
+                await connection.SendMethodReturnAsync(replySerial, header.Sender, sendBody, "a{oa{sa{sv}}}").ConfigureAwait(false);
+            }
+
+        }
+
+        public void EncodeProperties(List<byte> sendBody, ref int index)
+        {
+            throw new DbusException(
+                    DbusException.CreateErrorName("InvalidCall"),
+                    "ObjectManager has no Properties"
+                );
+        }
+
+        public void EncodeProperty(List<byte> sendBody, ref int index, string requestedProperty)
+        {
+            throw new DbusException(
+                    DbusException.CreateErrorName("InvalidCall"),
+                    "ObjectManager has no Properties"
+                );
+        }
+
+
+        private static void assertSignature(global::Dbus.Signature actual, global::Dbus.Signature expected)
+        {
+            if (actual != expected)
+                throw new DbusException(
+                    DbusException.CreateErrorName("InvalidSignature"),
+                    "Invalid signature"
+                );
+        }
+
+        public void Dispose()
+        {
+            registration.Dispose();
+        }
+
+
+    }
+}

--- a/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
@@ -13,7 +13,6 @@ namespace Dbus
         private readonly IOrgFreedesktopDbusObjectManagerProvide target;
         private readonly ObjectPath path;
 
-
         private IDisposable registration;
 
         private OrgFreedesktopDbusObjectManager_Proxy(Connection connection, IOrgFreedesktopDbusObjectManagerProvide target, ObjectPath path)
@@ -87,7 +86,6 @@ namespace Dbus
                 }, true);
                 await connection.SendMethodReturnAsync(replySerial, header.Sender, sendBody, "a{oa{sa{sv}}}").ConfigureAwait(false);
             }
-
         }
 
         public void EncodeProperties(List<byte> sendBody, ref int index)
@@ -120,7 +118,5 @@ namespace Dbus
         {
             registration.Dispose();
         }
-
-
     }
 }

--- a/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
+++ b/src/Dbus/OrgFreedesktopDbusObjectManager_Proxy.cs
@@ -17,12 +17,14 @@ namespace Dbus
 
         private OrgFreedesktopDbusObjectManager_Proxy(Connection connection, IOrgFreedesktopDbusObjectManagerProvide target, ObjectPath path)
         {
+            if (path == null)
+                throw new ArgumentNullException("An ObjectManager needs a path!");
             this.connection = connection;
             this.target = target;
             this.path = path;
             InterfaceName = "org.freedesktop.DBus.ObjectManager";
             registration = connection.RegisterObjectProxy(
-                path ?? "",
+                path,
                 InterfaceName,
                 this
             );
@@ -34,7 +36,6 @@ namespace Dbus
         }
 
         public void Encode(List<byte> sendBody, ref int sendIndex)
-
         {
             Encoder.AddArray(sendBody, ref sendIndex, (List<byte> sendBody_e, ref int sendIndex_e) =>
             {


### PR DESCRIPTION
New features:
The org.freedesktop.DBus.ObjectManager interface is now implemented for the provide side. The corresponding classes are OrgFreedesktopDbusObjectManager and OrgFreedesktopDbusObjectManager_Proxy.
The Connection class is now able to send signals.
Proxies now implement methods required to support the org.freedesktop.DBus.Properties and org.freedesktop.DBus.ObjectManager interfaces.
The Connection class now recognizes calls to the org.freedesktop.DBus.Properties interface and handles them accordingly.
